### PR TITLE
fix: remove all trailing spaces from short commit hashes

### DIFF
--- a/stats/page_load_data.json
+++ b/stats/page_load_data.json
@@ -1,7 +1,7 @@
 {
   "be2a96a664f5d07a63d0f88d8d2ada6d9a07ef4b": {
     "timestamp": 1756386778012,
-    "commit": "be2a96a\n",
+    "commit": "be2a96a",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -53,7 +53,7 @@
   },
   "98b23238b83ff979f20693f3363377eedb0af85d": {
     "timestamp": 1756388562022,
-    "commit": "98b2323\n",
+    "commit": "98b2323",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -105,7 +105,7 @@
   },
   "789fb1d52d447994ac155950f0fac0c66482545a": {
     "timestamp": 1756391555923,
-    "commit": "789fb1d\n",
+    "commit": "789fb1d",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -157,7 +157,7 @@
   },
   "52951b98f01704114e94682fdf4bfd38fea2b05a": {
     "timestamp": 1756393326312,
-    "commit": "52951b9\n",
+    "commit": "52951b9",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -209,7 +209,7 @@
   },
   "ac05ea6cc5ff10419c5d21552ecb40372eb10f95": {
     "timestamp": 1756395119440,
-    "commit": "ac05ea6\n",
+    "commit": "ac05ea6",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -261,7 +261,7 @@
   },
   "7c3a04e9ba96e1e7fa3366dc3e6dfad4eba9915b": {
     "timestamp": 1756396752589,
-    "commit": "7c3a04e\n",
+    "commit": "7c3a04e",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -313,7 +313,7 @@
   },
   "e0706279e46ba0c75db9c1f024007a5e06d6c6b4": {
     "timestamp": 1756398582844,
-    "commit": "e070627\n",
+    "commit": "e070627",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -365,7 +365,7 @@
   },
   "1892474c842e1495f1bc775bc21fed46f97127cf": {
     "timestamp": 1756401463012,
-    "commit": "1892474\n",
+    "commit": "1892474",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -417,7 +417,7 @@
   },
   "cb204a5544c14163d5907bd512a5c89561f0edf8": {
     "timestamp": 1756403224731,
-    "commit": "cb204a5\n",
+    "commit": "cb204a5",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -469,7 +469,7 @@
   },
   "1dbe448b3d6669757baf86e171d46c7df989f466": {
     "timestamp": 1756404883314,
-    "commit": "1dbe448\n",
+    "commit": "1dbe448",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -521,7 +521,7 @@
   },
   "a8b551d921b453508bce6cd1b9fab077129f6f15": {
     "timestamp": 1756406534295,
-    "commit": "a8b551d\n",
+    "commit": "a8b551d",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -573,7 +573,7 @@
   },
   "d336863a96d9a51a3a08c997a1d8625177ac6115": {
     "timestamp": 1756408471714,
-    "commit": "d336863\n",
+    "commit": "d336863",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -625,7 +625,7 @@
   },
   "5f5bfa7a8897d21e8dfe58b09eb4a6bb64eeda30": {
     "timestamp": 1756429869684,
-    "commit": "5f5bfa7\n",
+    "commit": "5f5bfa7",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -677,7 +677,7 @@
   },
   "1cde05b0bbc8acc9d8e054ff0dfd70ad5212db0d": {
     "timestamp": 1756453723625,
-    "commit": "1cde05b\n",
+    "commit": "1cde05b",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -729,7 +729,7 @@
   },
   "c81b6b5c6168548fa73df9f217d5aceb40d7cd2f": {
     "timestamp": 1756456078931,
-    "commit": "c81b6b5\n",
+    "commit": "c81b6b5",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -781,7 +781,7 @@
   },
   "4895cb77500a26ed6b5316d463c1dd29bfa64d96": {
     "timestamp": 1756463433693,
-    "commit": "4895cb7\n",
+    "commit": "4895cb7",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -833,7 +833,7 @@
   },
   "f76e0763189c18b33c4d5232524fd8be91799d83": {
     "timestamp": 1756465072008,
-    "commit": "f76e076\n",
+    "commit": "f76e076",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -885,7 +885,7 @@
   },
   "62e1a877d77b386e7e916ef312eb40184836ff4b": {
     "timestamp": 1756466715925,
-    "commit": "62e1a87\n",
+    "commit": "62e1a87",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -937,7 +937,7 @@
   },
   "9bfaaeb421052a30e659e466e5360401c06ab144": {
     "timestamp": 1756469168918,
-    "commit": "9bfaaeb\n",
+    "commit": "9bfaaeb",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -989,7 +989,7 @@
   },
   "afcb6565a71c7f128e0aaea926131c2b3613d783": {
     "timestamp": 1756472149364,
-    "commit": "afcb656\n",
+    "commit": "afcb656",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -1041,7 +1041,7 @@
   },
   "13e3cbc92cd00539be4a35506fd5910e304c5124": {
     "timestamp": 1756474669077,
-    "commit": "13e3cbc\n",
+    "commit": "13e3cbc",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -1093,7 +1093,7 @@
   },
   "753f24e28464f96dcbfcae35ed59d874364d2a60": {
     "timestamp": 1756476561925,
-    "commit": "753f24e\n",
+    "commit": "753f24e",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -1145,7 +1145,7 @@
   },
   "cd85effc666c6165724a8d1c33549bf4a9c4c546": {
     "timestamp": 1756478207675,
-    "commit": "cd85eff\n",
+    "commit": "cd85eff",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -1197,7 +1197,7 @@
   },
   "1d96cffca412c8935f3796b652dea8d7a1096b95": {
     "timestamp": 1756479889506,
-    "commit": "1d96cff\n",
+    "commit": "1d96cff",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -1249,7 +1249,7 @@
   },
   "597e6dbbfcce80c21110f058d5e5ae11b56bd6cb": {
     "timestamp": 1756482981308,
-    "commit": "597e6db\n",
+    "commit": "597e6db",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -1301,7 +1301,7 @@
   },
   "e2290723501517633fa03356f2540991517e3a20": {
     "timestamp": 1756485854028,
-    "commit": "e229072\n",
+    "commit": "e229072",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -1353,7 +1353,7 @@
   },
   "a9dc8f688177f75930a8b214b0ec93b87b70c034": {
     "timestamp": 1756492483590,
-    "commit": "a9dc8f6\n",
+    "commit": "a9dc8f6",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -1405,7 +1405,7 @@
   },
   "251a358abcf5e34afce246c65fdb3c3fd1c605ee": {
     "timestamp": 1756509741730,
-    "commit": "251a358\n",
+    "commit": "251a358",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -1457,7 +1457,7 @@
   },
   "cce5daa28a098beeea7408add91902645d2eaef8": {
     "timestamp": 1756512913743,
-    "commit": "cce5daa\n",
+    "commit": "cce5daa",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -1509,7 +1509,7 @@
   },
   "25ec962c006646a80743aa1cb3008d3d0a67f799": {
     "timestamp": 1756717648163,
-    "commit": "25ec962\n",
+    "commit": "25ec962",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -1561,7 +1561,7 @@
   },
   "20564639932e142aef5982bd0e07440007be8186": {
     "timestamp": 1756721425575,
-    "commit": "2056463\n",
+    "commit": "2056463",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -1613,7 +1613,7 @@
   },
   "5b65fa2b4ff45b00cce227ff73895ce516ebb9fd": {
     "timestamp": 1756729120267,
-    "commit": "5b65fa2\n",
+    "commit": "5b65fa2",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -1665,7 +1665,7 @@
   },
   "07b3e53851402ac7d381071610623deb8878ad7c": {
     "timestamp": 1756737947464,
-    "commit": "07b3e53\n",
+    "commit": "07b3e53",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -1717,7 +1717,7 @@
   },
   "af0e01756de85e563b74e262300a8432ea86187d": {
     "timestamp": 1756739580612,
-    "commit": "af0e017\n",
+    "commit": "af0e017",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -1769,7 +1769,7 @@
   },
   "892b20db74e75681bfd543bff4a419d6db7a4639": {
     "timestamp": 1756741236169,
-    "commit": "892b20d\n",
+    "commit": "892b20d",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -1821,7 +1821,7 @@
   },
   "329ac8c417c11279f1a0b738afa2e0f9ea402e80": {
     "timestamp": 1756744929320,
-    "commit": "329ac8c\n",
+    "commit": "329ac8c",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -1873,7 +1873,7 @@
   },
   "0f8ce5491b0801e66088cb75b941e5c757072dc6": {
     "timestamp": 1756746711907,
-    "commit": "0f8ce54\n",
+    "commit": "0f8ce54",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -1925,7 +1925,7 @@
   },
   "e085b4225145010b3cf25ee45fc363008e8f014a": {
     "timestamp": 1756756819584,
-    "commit": "e085b42\n",
+    "commit": "e085b42",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -1977,7 +1977,7 @@
   },
   "0d7e5ced0abcceb61ae7a880041a44d60d19950c": {
     "timestamp": 1756804297912,
-    "commit": "0d7e5ce\n",
+    "commit": "0d7e5ce",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -2029,7 +2029,7 @@
   },
   "1df169b05a43a77b4b3518de73f9f31735725680": {
     "timestamp": 1756805887511,
-    "commit": "1df169b\n",
+    "commit": "1df169b",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -2081,7 +2081,7 @@
   },
   "b764cd15679eedf4af27d7489cbcb1666e40563f": {
     "timestamp": 1756810577298,
-    "commit": "b764cd1\n",
+    "commit": "b764cd1",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -2133,7 +2133,7 @@
   },
   "d6c9db258a34f91bbc22d4fd1a59581cb756fd17": {
     "timestamp": 1756812845097,
-    "commit": "d6c9db2\n",
+    "commit": "d6c9db2",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -2185,7 +2185,7 @@
   },
   "f990868b03fa890aeb3748dcef04b7661473d16a": {
     "timestamp": 1756819598342,
-    "commit": "f990868\n",
+    "commit": "f990868",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -2237,7 +2237,7 @@
   },
   "2ff66f685cb0f89aad1a0b37f3e94df373c9eaf5": {
     "timestamp": 1756823614198,
-    "commit": "2ff66f6\n",
+    "commit": "2ff66f6",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -2289,7 +2289,7 @@
   },
   "9a452fe50b2fa91e9888f3a2d853a72d30ff0c64": {
     "timestamp": 1756825268797,
-    "commit": "9a452fe\n",
+    "commit": "9a452fe",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -2341,7 +2341,7 @@
   },
   "ebe889c13ecd234c620a2b03f72b4430a00e742f": {
     "timestamp": 1756827097770,
-    "commit": "ebe889c\n",
+    "commit": "ebe889c",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -2393,7 +2393,7 @@
   },
   "ab0879a17b8a2db0b848f36c94f5852fbc045893": {
     "timestamp": 1756838126140,
-    "commit": "ab0879a\n",
+    "commit": "ab0879a",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -2445,7 +2445,7 @@
   },
   "a88b9d5ca0d9927ddca85db175c43357c941ccfa": {
     "timestamp": 1756839862615,
-    "commit": "a88b9d5\n",
+    "commit": "a88b9d5",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -2497,7 +2497,7 @@
   },
   "c3d75a8b85ef1e48f28dcfa947a3d262e26232ac": {
     "timestamp": 1756842332494,
-    "commit": "c3d75a8\n",
+    "commit": "c3d75a8",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -2549,7 +2549,7 @@
   },
   "712e03d75b88f945f10f130fde313fd4b4e10570": {
     "timestamp": 1756857067839,
-    "commit": "712e03d\n",
+    "commit": "712e03d",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -2601,7 +2601,7 @@
   },
   "234204e2d28e621c87813fa1f8347bef9ac9f371": {
     "timestamp": 1756858665768,
-    "commit": "234204e\n",
+    "commit": "234204e",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -2653,7 +2653,7 @@
   },
   "3f23d469867df54825138478c25e3ea0b4f514c7": {
     "timestamp": 1756860849991,
-    "commit": "3f23d46\n",
+    "commit": "3f23d46",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -2705,7 +2705,7 @@
   },
   "e47af1148fb896a9129f9418873ab1843bec6645": {
     "timestamp": 1756865693380,
-    "commit": "e47af11\n",
+    "commit": "e47af11",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -2757,7 +2757,7 @@
   },
   "13956cbf1661041be2a9311e4381af2aa20b872a": {
     "timestamp": 1756891746060,
-    "commit": "13956cb\n",
+    "commit": "13956cb",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -2809,7 +2809,7 @@
   },
   "b0b6d3cc1b77c8f93bbfc4a49cd46a9fb8624e25": {
     "timestamp": 1756893525634,
-    "commit": "b0b6d3c\n",
+    "commit": "b0b6d3c",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -2861,7 +2861,7 @@
   },
   "eda82b03f84b48750fac76a4291191a40dba0717": {
     "timestamp": 1756895189641,
-    "commit": "eda82b0\n",
+    "commit": "eda82b0",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -2913,7 +2913,7 @@
   },
   "0e0e4b74bab6dccd9957baaa2c3de3a38de4d092": {
     "timestamp": 1756899111736,
-    "commit": "0e0e4b7\n",
+    "commit": "0e0e4b7",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -2965,7 +2965,7 @@
   },
   "5c88f6d4de78ed435ac39e935dae027b53c1ecee": {
     "timestamp": 1756903487368,
-    "commit": "5c88f6d\n",
+    "commit": "5c88f6d",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -3017,7 +3017,7 @@
   },
   "67c59eb3c86b120d47bc218804355b3dab7c8bd1": {
     "timestamp": 1756908231296,
-    "commit": "67c59eb\n",
+    "commit": "67c59eb",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -3069,7 +3069,7 @@
   },
   "8f653e86eab28f8908748ad36f74380a7d7d6fcc": {
     "timestamp": 1756910133203,
-    "commit": "8f653e8\n",
+    "commit": "8f653e8",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -3121,7 +3121,7 @@
   },
   "1a2619ac4e9486ef667599f9258b21c6f37585ce": {
     "timestamp": 1756916296217,
-    "commit": "1a2619a\n",
+    "commit": "1a2619a",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -3173,7 +3173,7 @@
   },
   "cbaa0e32b07501e58695018fb3b0bdcaa2556851": {
     "timestamp": 1756918004239,
-    "commit": "cbaa0e3\n",
+    "commit": "cbaa0e3",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -3225,7 +3225,7 @@
   },
   "f2f720cc60a7acdae6b38a318276c88fad82e06f": {
     "timestamp": 1756919785103,
-    "commit": "f2f720c\n",
+    "commit": "f2f720c",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -3277,7 +3277,7 @@
   },
   "285eb039ba1be8b21a813b2928733b52cda77596": {
     "timestamp": 1756921422884,
-    "commit": "285eb03\n",
+    "commit": "285eb03",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -3329,7 +3329,7 @@
   },
   "be98e966ef64e0448ae231a4cefd80dec9a2f119": {
     "timestamp": 1756923116204,
-    "commit": "be98e96\n",
+    "commit": "be98e96",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -3381,7 +3381,7 @@
   },
   "4200f2ddb0e92c7fb146fc476bebe271b54b350a": {
     "timestamp": 1756925076761,
-    "commit": "4200f2d\n",
+    "commit": "4200f2d",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -3433,7 +3433,7 @@
   },
   "83c685d8a07f3172f5fa3c9462ecd7846485dea9": {
     "timestamp": 1756928892940,
-    "commit": "83c685d\n",
+    "commit": "83c685d",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -3485,7 +3485,7 @@
   },
   "8d838e09681dba5c357328e972940146ca648356": {
     "timestamp": 1756968926676,
-    "commit": "8d838e0\n",
+    "commit": "8d838e0",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -3537,7 +3537,7 @@
   },
   "52d243265c87fc116adc0381136d67c6ae0b9171": {
     "timestamp": 1756970709389,
-    "commit": "52d2432\n",
+    "commit": "52d2432",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -3589,7 +3589,7 @@
   },
   "35b8ecd63fc894ebde99649caa17401816c9f409": {
     "timestamp": 1756974207022,
-    "commit": "35b8ecd\n",
+    "commit": "35b8ecd",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -3641,7 +3641,7 @@
   },
   "ef0905a90ee4c63f6a80027244d97e1fe08f737c": {
     "timestamp": 1756976226440,
-    "commit": "ef0905a\n",
+    "commit": "ef0905a",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -3693,7 +3693,7 @@
   },
   "ca9ea09b6da32c38c14a732c489e68ade5b8c637": {
     "timestamp": 1756980296063,
-    "commit": "ca9ea09\n",
+    "commit": "ca9ea09",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -3745,7 +3745,7 @@
   },
   "1d80998e310797e58b27d56a2433ab8331955916": {
     "timestamp": 1756982039379,
-    "commit": "1d80998\n",
+    "commit": "1d80998",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -3797,7 +3797,7 @@
   },
   "7495a2c022f6ee26303f6f2896fafe6fbf70a008": {
     "timestamp": 1756990521162,
-    "commit": "7495a2c\n",
+    "commit": "7495a2c",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -3849,7 +3849,7 @@
   },
   "5ec071dce84ec8a26436d8041ffafb8fc93af4b3": {
     "timestamp": 1756992477869,
-    "commit": "5ec071d\n",
+    "commit": "5ec071d",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -3901,7 +3901,7 @@
   },
   "3d8349cfab2f19a578e403dcad16b1077792201d": {
     "timestamp": 1756994083167,
-    "commit": "3d8349c\n",
+    "commit": "3d8349c",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -3953,7 +3953,7 @@
   },
   "3512630d79f45b19439b3cf57b2230638405efec": {
     "timestamp": 1756995786302,
-    "commit": "3512630\n",
+    "commit": "3512630",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -4005,7 +4005,7 @@
   },
   "c4386600b0c2c2a5ed5ce371fe4c968a6214e5b2": {
     "timestamp": 1756998358143,
-    "commit": "c438660\n",
+    "commit": "c438660",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -4057,7 +4057,7 @@
   },
   "5e3085daddc339f582d02f49acbd7522dccb54b0": {
     "timestamp": 1757004211764,
-    "commit": "5e3085d\n",
+    "commit": "5e3085d",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -4109,7 +4109,7 @@
   },
   "5b92a06e3c8027b0439d4f0557ac98f7e0dbd3da": {
     "timestamp": 1757008205576,
-    "commit": "5b92a06\n",
+    "commit": "5b92a06",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -4161,7 +4161,7 @@
   },
   "3cb56695a4d9c9da23e744620e81f66dff403a1e": {
     "timestamp": 1757010445887,
-    "commit": "3cb5669\n",
+    "commit": "3cb5669",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -4213,7 +4213,7 @@
   },
   "39e10fd93c95ff39f1a30b2a78398622b8751c51": {
     "timestamp": 1757014774907,
-    "commit": "39e10fd\n",
+    "commit": "39e10fd",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -4265,7 +4265,7 @@
   },
   "d58228a8b4289840036ee5e5acfd453e73d6188e": {
     "timestamp": 1757016992135,
-    "commit": "d58228a\n",
+    "commit": "d58228a",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -4317,7 +4317,7 @@
   },
   "7e41aa9171ad181bdd1e09077c4eda6c91cb315b": {
     "timestamp": 1757027532323,
-    "commit": "7e41aa9\n",
+    "commit": "7e41aa9",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -4369,7 +4369,7 @@
   },
   "35727655c9a8c63096b8657a7d2b004f1b4b8617": {
     "timestamp": 1757058692691,
-    "commit": "3572765\n",
+    "commit": "3572765",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -4421,7 +4421,7 @@
   },
   "df410a61d9c836388e9d77afee5d45ee981d8393": {
     "timestamp": 1757060828833,
-    "commit": "df410a6\n",
+    "commit": "df410a6",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -4473,7 +4473,7 @@
   },
   "cf060bcb1c466c4c9ae3aa48c6fe403d8d7e4c69": {
     "timestamp": 1757066804527,
-    "commit": "cf060bc\n",
+    "commit": "cf060bc",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -4525,7 +4525,7 @@
   },
   "1da82ae2d000af444f6a41eb61e849e5c10b7b94": {
     "timestamp": 1757077610307,
-    "commit": "1da82ae\n",
+    "commit": "1da82ae",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -4577,7 +4577,7 @@
   },
   "6ab431a8973fc42cb0b89079e3ff8d88bac21b2a": {
     "timestamp": 1757079389137,
-    "commit": "6ab431a\n",
+    "commit": "6ab431a",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -4629,7 +4629,7 @@
   },
   "a224f705511526366b5d8ec427956ec815c2bca8": {
     "timestamp": 1757081359056,
-    "commit": "a224f70\n",
+    "commit": "a224f70",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -4681,7 +4681,7 @@
   },
   "1d85b91672d0cd7334e51894d3fd5f1165685e94": {
     "timestamp": 1757083566426,
-    "commit": "1d85b91\n",
+    "commit": "1d85b91",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -4733,7 +4733,7 @@
   },
   "c16aefbb97fad078da8cc1b6793c014ddba65492": {
     "timestamp": 1757087711047,
-    "commit": "c16aefb\n",
+    "commit": "c16aefb",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -4785,7 +4785,7 @@
   },
   "353a1e7c2794a96ea2f14cbf09a75910e32a7648": {
     "timestamp": 1757089670901,
-    "commit": "353a1e7\n",
+    "commit": "353a1e7",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -4837,7 +4837,7 @@
   },
   "769cca21f8af88d05b2361e78fb42f7b08cce85b": {
     "timestamp": 1757091346036,
-    "commit": "769cca2\n",
+    "commit": "769cca2",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -4889,7 +4889,7 @@
   },
   "84bb66c102dcf243431cd29c37d9ea2ed6fe41f9": {
     "timestamp": 1757101984327,
-    "commit": "84bb66c\n",
+    "commit": "84bb66c",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -4941,7 +4941,7 @@
   },
   "f93d7ed6a157b2cfb6d87b5468a71d353e4bad2d": {
     "timestamp": 1757104569237,
-    "commit": "f93d7ed\n",
+    "commit": "f93d7ed",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -4993,7 +4993,7 @@
   },
   "a67fae57b3e45f8cdc667aac23c475d8057870aa": {
     "timestamp": 1757107634363,
-    "commit": "a67fae5\n",
+    "commit": "a67fae5",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -5045,7 +5045,7 @@
   },
   "68ac52884fc0cd1d0d9f35dba4cef1a9ee17f691": {
     "timestamp": 1757315685590,
-    "commit": "68ac528\n",
+    "commit": "68ac528",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -5097,7 +5097,7 @@
   },
   "8f673db20e9f65eeba87162dc2361aeb0cf071a1": {
     "timestamp": 1757321430335,
-    "commit": "8f673db\n",
+    "commit": "8f673db",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -5149,7 +5149,7 @@
   },
   "a4d6c44acdb9fa8832bc1edb4117013e77dc9948": {
     "timestamp": 1757323304859,
-    "commit": "a4d6c44\n",
+    "commit": "a4d6c44",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -5201,7 +5201,7 @@
   },
   "2945564ddd7e0f0d6a72a390710e7926c3e64d4b": {
     "timestamp": 1757325405641,
-    "commit": "2945564\n",
+    "commit": "2945564",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -5253,7 +5253,7 @@
   },
   "54b473b70b986e9bf5c748378beb5b58b54fee5f": {
     "timestamp": 1757331407203,
-    "commit": "54b473b\n",
+    "commit": "54b473b",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -5305,7 +5305,7 @@
   },
   "dcdb001cb10a169eacd72640fd5d65b0855c5aaf": {
     "timestamp": 1757335737564,
-    "commit": "dcdb001\n",
+    "commit": "dcdb001",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -5357,7 +5357,7 @@
   },
   "830d2c4f92293f97b035ed0bd67b145b45aabf85": {
     "timestamp": 1757339450499,
-    "commit": "830d2c4\n",
+    "commit": "830d2c4",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -5409,7 +5409,7 @@
   },
   "70a753fcde2dfb166c30fefbbae7b88cef727a53": {
     "timestamp": 1757343730718,
-    "commit": "70a753f\n",
+    "commit": "70a753f",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -5461,7 +5461,7 @@
   },
   "cc4c4b5722c8c1ab68374365dc01e207c077a104": {
     "timestamp": 1757363291139,
-    "commit": "cc4c4b5\n",
+    "commit": "cc4c4b5",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -5513,7 +5513,7 @@
   },
   "de8db53703a0754224f5f3ef0e09bf5da261cef0": {
     "timestamp": 1757364938011,
-    "commit": "de8db53\n",
+    "commit": "de8db53",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -5565,7 +5565,7 @@
   },
   "cb1da5a35c3626fd94296a93013b27b97e3bc484": {
     "timestamp": 1757366652875,
-    "commit": "cb1da5a\n",
+    "commit": "cb1da5a",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -5617,7 +5617,7 @@
   },
   "137c468ff7565e4392dd9caa72202a7ab05755e8": {
     "timestamp": 1757368291135,
-    "commit": "137c468\n",
+    "commit": "137c468",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -5669,7 +5669,7 @@
   },
   "a8379e8ce3814d53778118364894ece53ca77074": {
     "timestamp": 1757385788701,
-    "commit": "a8379e8\n",
+    "commit": "a8379e8",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -5721,7 +5721,7 @@
   },
   "f4bf5e2e7a5fc06330be9aeee3e76815eb9c8815": {
     "timestamp": 1757406852177,
-    "commit": "f4bf5e2\n",
+    "commit": "f4bf5e2",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -5773,7 +5773,7 @@
   },
   "9fbcac1fbf973ecf23661340f3ccf134f9ccb3e6": {
     "timestamp": 1757410821691,
-    "commit": "9fbcac1\n",
+    "commit": "9fbcac1",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -5825,7 +5825,7 @@
   },
   "7d955c218ef85c48d0c55586a84ca375af98739b": {
     "timestamp": 1757412605010,
-    "commit": "7d955c2\n",
+    "commit": "7d955c2",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",
@@ -5877,7 +5877,7 @@
   },
   "b7dc5ff8778aab0049fc98147aac5cb7e04112be": {
     "timestamp": 1757416443679,
-    "commit": "b7dc5ff\n",
+    "commit": "b7dc5ff",
     "summary": [
       {
         "page": "https://metamask.github.io/test-dapp/",


### PR DESCRIPTION
Before https://github.com/MetaMask/metamask-extension/pull/35766 on extension, all updates to historical JSON entries on `commit` field contained breaking space characters.

This PR removes them from previously introduced entries.